### PR TITLE
Fix the bug of endless bucket doubling when min_load_factor=0.

### DIFF
--- a/src/sparsehash/internal/densehashtable.h
+++ b/src/sparsehash/internal/densehashtable.h
@@ -588,13 +588,14 @@ class dense_hashtable {
     // are currently taking up room).  But later, when we decide what
     // size to resize to, *don't* count deleted buckets, since they
     // get discarded during the resize.
-    const size_type needed_size = settings.min_buckets(num_elements + delta, 0);
+    size_type needed_size = settings.min_buckets(num_elements + delta, 0);
     if ( needed_size <= bucket_count() )      // we have enough buckets
       return did_resize;
 
     size_type resize_to =
       settings.min_buckets(num_elements - num_deleted + delta, bucket_count());
 
+    needed_size = settings.min_buckets(num_elements - num_deleted / 4 + delta, 0);
     if (resize_to < needed_size &&    // may double resize_to
         resize_to < (std::numeric_limits<size_type>::max)() / 2) {
       // This situation means that we have enough deleted elements,

--- a/src/sparsehash/internal/densehashtable.h
+++ b/src/sparsehash/internal/densehashtable.h
@@ -595,6 +595,11 @@ class dense_hashtable {
     size_type resize_to =
       settings.min_buckets(num_elements - num_deleted + delta, bucket_count());
 
+    // When num_deleted is large, we may still grow but we do not want to
+    // over expand.  So we reduce needed_size by a portion of num_deleted
+    // (the exact portion does not matter).  This is especially helpful
+    // when min_load_factor is zero (no shrink at all) to avoid doubling
+    // the bucket count to infinity.  See also test ResizeWithoutShrink.
     needed_size = settings.min_buckets(num_elements - num_deleted / 4 + delta, 0);
     if (resize_to < needed_size &&    // may double resize_to
         resize_to < (std::numeric_limits<size_type>::max)() / 2) {


### PR DESCRIPTION
When min_load_factor = 0, the dense_hash_map may keep doubling its bucket size even though the actual need is small (as long as we keep inserting/deleting entries).  This patch fixes the bug, while trying to keep the original logic of preparing for an immediate resize.