### PR TITLE
Prevent compiler warning when compiled with -Wformat-pedantic

### DIFF
--- a/src/sparsehash/internal/densehashtable.h
+++ b/src/sparsehash/internal/densehashtable.h
@@ -1202,7 +1202,8 @@ class dense_hashtable {
       pointer retval = this->reallocate(ptr, n);
       if (retval == NULL) {
         fprintf(stderr, "sparsehash: FATAL ERROR: failed to reallocate "
-                "%lu elements for ptr %p", static_cast<unsigned long>(n), ptr);
+                "%lu elements for ptr %p", static_cast<unsigned long>(n),
+                (void*)ptr);
         exit(1);
       }
       return retval;


### PR DESCRIPTION
The issued warning is (from Clang):
`warning: format specifies type 'void *' but the argument has type 'pointer'`
