### PR TITLE
Fix a couple issues in benchmark program

### DIFF
--- a/src/hashtable_test.cc
+++ b/src/hashtable_test.cc
@@ -249,10 +249,10 @@ struct Alloc {
     typedef Alloc<U, SizeT, MAX_SIZE> other;
   };
 
-  bool operator==(const Alloc<T,SizeT,MAX_SIZE>& that) {
+  bool operator==(const Alloc& that) const {
     return this->id_ == that.id_ && this->count_ == that.count_;
   }
-  bool operator!=(const Alloc<T,SizeT,MAX_SIZE>& that) {
+  bool operator!=(const Alloc& that) const {
     return !this->operator==(that);
   }
 

--- a/src/sparsehash/xargs.exe.stackdump
+++ b/src/sparsehash/xargs.exe.stackdump
@@ -1,9 +1,0 @@
-Exception: STATUS_ACCESS_VIOLATION at eip=610CA055
-eax=00A0CE64 ebx=FFFFFFD9 ecx=0A225F69 edx=198ACC28 esi=61169220 edi=00000000
-ebp=198ACD28 esp=198ACC50 program=c:\cygwin\bin\xargs.exe, pid 14016, thread sig
-cs=0023 ds=002B es=002B fs=0053 gs=002B ss=002B
-Stack trace:
-Frame     Function  Args
-198ACD28  610CA055  (61169220, 00000000, 00000000, 00000000)
-198ACD58  61003F51  (00000000, 00000000, 00000000, 61004A63)
-End of stack trace

--- a/src/sparsehash/xargs.exe.stackdump
+++ b/src/sparsehash/xargs.exe.stackdump
@@ -1,0 +1,9 @@
+Exception: STATUS_ACCESS_VIOLATION at eip=610CA055
+eax=00A0CE64 ebx=FFFFFFD9 ecx=0A225F69 edx=198ACC28 esi=61169220 edi=00000000
+ebp=198ACD28 esp=198ACC50 program=c:\cygwin\bin\xargs.exe, pid 14016, thread sig
+cs=0023 ds=002B es=002B fs=0053 gs=002B ss=002B
+Stack trace:
+Frame     Function  Args
+198ACD28  610CA055  (61169220, 00000000, 00000000, 00000000)
+198ACD58  61003F51  (00000000, 00000000, 00000000, 61004A63)
+End of stack trace

--- a/src/time_hash_map.cc
+++ b/src/time_hash_map.cc
@@ -222,14 +222,7 @@ template<int Size, int Hashsize> class HashObject {
   size_t Hash() const {
     g_num_hashes++;
     int hashval = i_;
-
-    // ridiculously slow hash for 256 byte objects when hashing byte by byte 
-    // all 252 bytes - hash time overwhelms any reasonable comparison between 
-    // implementations.
-    size_t num_bytes_to_hash = Hashsize - sizeof(i_);
-    if (num_bytes_to_hash > 4)
-        num_bytes_to_hash = 4;
-    for (size_t i = 0; i < num_bytes_to_hash; ++i) {
+    for (size_t i = 0; i < Hashsize - sizeof(i_); ++i) {
       hashval += buffer_[i];
     }
     return SPARSEHASH_HASH<int>()(hashval);
@@ -730,7 +723,7 @@ int main(int argc, char** argv) {
   if (FLAGS_test_4_bytes)  test_all_maps< HashObject<4,4> >(4, iters/1);
   if (FLAGS_test_8_bytes)  test_all_maps< HashObject<8,8> >(8, iters/2);
   if (FLAGS_test_16_bytes)  test_all_maps< HashObject<16,16> >(16, iters/4);
-  if (FLAGS_test_256_bytes)  test_all_maps< HashObject<256,256> >(256, iters/32);
+  if (FLAGS_test_256_bytes)  test_all_maps< HashObject<256,32> >(256, iters/32);
 
   return 0;
 }


### PR DESCRIPTION
Initialize g_num_copies and g_num_hashes when test starts. Also speedup
hash computation for large objects.