### PR TITLE
Fix missing initialization of g_num_copies and g_num_hashes

### DIFF
--- a/src/time_hash_map.cc
+++ b/src/time_hash_map.cc
@@ -331,6 +331,8 @@ class Rusage {
 };
 
 inline void Rusage::Reset() {
+  g_num_copies = 0;
+  g_num_hashes = 0;
 #if defined HAVE_SYS_RESOURCE_H
   getrusage(RUSAGE_SELF, &start);
 #elif defined HAVE_WINDOWS_H


### PR DESCRIPTION
When running the benchmark, the numbers of copies and hashes reported is
constantly increasing, as the values were not reset when starting the
test. This commit fixes this, and does not change the benchmark itself
or reported times.