### PR TITLE
Update test for large objects with a more reasonable hash function.

### DIFF
--- a/src/time_hash_map.cc
+++ b/src/time_hash_map.cc
@@ -723,7 +723,7 @@ int main(int argc, char** argv) {
   if (FLAGS_test_4_bytes)  test_all_maps< HashObject<4,4> >(4, iters/1);
   if (FLAGS_test_8_bytes)  test_all_maps< HashObject<8,8> >(8, iters/2);
   if (FLAGS_test_16_bytes)  test_all_maps< HashObject<16,16> >(16, iters/4);
-  if (FLAGS_test_256_bytes)  test_all_maps< HashObject<256,256> >(256, iters/32);
+  if (FLAGS_test_256_bytes)  test_all_maps< HashObject<256,32> >(256, iters/32);
 
   return 0;
 }


### PR DESCRIPTION
The HashObject uses the following code in the Hash() function:

```
size_t Hash() const {
  g_num_hashes++;
  int hashval = i_;
  for (size_t i = 0; i < Hashsize - sizeof(i_); ++i) {
     hashval += buffer_[i];
  }
  return SPARSEHASH_HASH<int>()(hashval);
}
```

As you can see, when Hashsize is specified as 256, the Hash() function
will iterate and sum 252 bytes.
This is a big contributor to the time spent in sparse, dense and
unordered_map tests, and I feel is unfair when comparing with the
std::map, because the HashObject comparison function compares only the
"i_" member:

```
bool operator==(const class_type& that) const { return this->i_ ==
that.i_; }
bool operator< (const class_type& that) const { return this->i_ <
that.i_; }
bool operator<=(const class_type& that) const { return this->i_ <=
that.i_; }
```

Also, it is not typical for hash functions to take a lot of time to compute everytime the object is inserted or a lookup is performed. If indeed the hash computation is complex and must refer to many members, it should be computed once on demand and stored in the object.