### PR TITLE
Correct the memory usage claims to take into account allocator memory usage

### DIFF
--- a/README
+++ b/README
@@ -106,13 +106,13 @@ SPARSETABLE
 In addition to the hash-map and hash-set classes, this package also
 provides sparsetable.h, an array implementation that uses space
 proportional to the number of elements in the array, rather than the
-maximum element index.  It uses very little space overhead: 1 bit per
-entry.  See doc/sparsetable.html for the API.
+maximum element index.  It uses very little space overhead: 2 to 5 
+bits per entry.  See doc/sparsetable.html for the API.
 
 RESOURCE USAGE
 --------------
-* sparse_hash_map has memory overhead of about 2 bits per hash-map
-  entry.
+* sparse_hash_map has memory overhead of about 2 to 6 bits per 
+  hash-map entry.
 * dense_hash_map has a factor of 2-3 memory overhead: if your
   hashtable data takes X bytes, dense_hash_map will use 3X-4X memory
   total.

--- a/doc/implementation.html
+++ b/doc/implementation.html
@@ -131,6 +131,12 @@ A larger M would use less overhead -- approaching 1 bit per array
 entry -- but take longer for inserts, deletes, and lookups.  A smaller
 M would use more overhead but make operations somewhat faster.</p>
 
+The numbers above assume that the allocator used doesn't require extra 
+memory. The default allocator (using malloc/free) typically has some overhead 
+for each allocation. If we assume 16 byte overhead per allocation, the 
+overhead becomes 4.6 bit per array entry (32 bit pointers) or 5 bit per 
+array entry (64 bit pointers) 
+
 <p>You can also look at some specific <A
 HREF="performance.html">performance numbers</A>.</p>
 

--- a/src/time_hash_map.cc
+++ b/src/time_hash_map.cc
@@ -331,6 +331,8 @@ class Rusage {
 };
 
 inline void Rusage::Reset() {
+  g_num_copies = 0;
+  g_num_hashes = 0;
 #if defined HAVE_SYS_RESOURCE_H
   getrusage(RUSAGE_SELF, &start);
 #elif defined HAVE_WINDOWS_H

--- a/src/time_hash_map.cc
+++ b/src/time_hash_map.cc
@@ -723,7 +723,7 @@ int main(int argc, char** argv) {
   if (FLAGS_test_4_bytes)  test_all_maps< HashObject<4,4> >(4, iters/1);
   if (FLAGS_test_8_bytes)  test_all_maps< HashObject<8,8> >(8, iters/2);
   if (FLAGS_test_16_bytes)  test_all_maps< HashObject<16,16> >(16, iters/4);
-  if (FLAGS_test_256_bytes)  test_all_maps< HashObject<256,256> >(256, iters/32);
+  if (FLAGS_test_256_bytes)  test_all_maps< HashObject<256,32> >(256, iters/32);
 
   return 0;
 }


### PR DESCRIPTION
The default memory allocator used (libc_allocator_with_realloc)
necessarily has some overhead, as the size of the block is not passed to
free(). The memory usage claims are updated to take into account an
overhead of up to 16 bytes per malloc'ed block.