### PR TITLE
Fix when T's namespace has global malloc/free/realloc functions

### DIFF
--- a/src/sparsehash/internal/libc_allocator_with_realloc.h
+++ b/src/sparsehash/internal/libc_allocator_with_realloc.h
@@ -59,13 +59,13 @@ class libc_allocator_with_realloc {
   const_pointer address(const_reference r) const  { return &r; }
 
   pointer allocate(size_type n, const_pointer = 0) {
-    return static_cast<pointer>(malloc(n * sizeof(value_type)));
+    return static_cast<pointer>(::malloc(n * sizeof(value_type)));
   }
   void deallocate(pointer p, size_type) {
-    free(p);
+    ::free(p);
   }
   pointer reallocate(pointer p, size_type n) {
-    return static_cast<pointer>(realloc(p, n * sizeof(value_type)));
+    return static_cast<pointer>(::realloc(p, n * sizeof(value_type)));
   }
 
   size_type max_size() const  {


### PR DESCRIPTION
If the namespace of the type used in the hashtable contains namespace-scope functions malloc, free, realloc, you get a compile error.  This qualifies calls to malloc, free and realloc at the global scope.