### PR TITLE
Correct memory overhead of sparse_hash_map in opening paragraph

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 This directory contains several hash-map implementations, similar in
 API to SGI's hash_map class, but with different performance
-characteristics.  sparse_hash_map uses very little space overhead, 1-2
+characteristics.  sparse_hash_map uses very little space overhead, 4-10
 bits per entry.  dense_hash_map is very fast, particulary on lookup.
 (sparse_hash_set and dense_hash_set are the set versions of these
 routines.)  On the other hand, these classes have requirements that


### PR DESCRIPTION
The correction lower down in the README file was already made by an earlier contributor; this edit is for consistency.