### PR TITLE
Prevent compiler warning about writing to an object with no trivial copy-assignment

### DIFF
--- a/src/sparsehash/sparsetable
+++ b/src/sparsehash/sparsetable
@@ -1088,7 +1088,9 @@ class sparsegroup {
     // This is equivalent to memmove(), but faster on my Intel P4,
     // at least with gcc4.1 -O2 / glibc 2.3.6.
     for (size_type i = settings.num_buckets; i > offset; --i)
-      memcpy(group + i, group + i-1, sizeof(*group));
+      // cast to void* to prevent compiler warnings about writing to an object
+      // with no trivial copy-assignment
+      memcpy(static_cast<void*>(group + i), group + i-1, sizeof(*group));
   }
 
   // Create space at group[offset], without special assumptions about value_type
@@ -1154,7 +1156,10 @@ class sparsegroup {
     // at lesat with gcc4.1 -O2 / glibc 2.3.6.
     assert(settings.num_buckets > 0);
     for (size_type i = offset; i < settings.num_buckets-1; ++i)
-      memcpy(group + i, group + i+1, sizeof(*group));  // hopefully inlined!
+      // cast to void* to prevent compiler warnings about writing to an object
+      // with no trivial copy-assignment
+      // hopefully inlined!
+      memcpy(static_cast<void*>(group + i), group + i+1, sizeof(*group));
     group = settings.realloc_or_die(group, settings.num_buckets-1);
   }
 


### PR DESCRIPTION
Fix sparetable part of #149.

The warnings are caused by differences between `google::has_trivial_copy` * `google::has_trivial_destructor` and `std::is_trivially_copyable` * `std::is_trivially_destructible`, henceforth referred to as google trivial and standard trivial.

In particularly, this causes warning in `time_hash_map.cc` because
1. If `T` and `U` are google trivial, `pair<T, U>` is also google trivial. However, `pair` is not standard trivial.
2. `HashObject` is declared to be google trivial in `time_hash_map.cc` explicitly even though it implements custom copy constructor and copy assignment.

This PR prevents the warnings by casting pointers to `void*` first before `memcpy`. This is fine as long as a google trivial type is really trivially copyable and destructible.