### PR TITLE
Fix version number

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@
 # make sure we're interpreted by some minimal autoconf
 AC_PREREQ(2.57)
 
-AC_INIT(sparsehash, 2.0.2, google-sparsehash@googlegroups.com)
+AC_INIT(sparsehash, 2.0.3, google-sparsehash@googlegroups.com)
 # The argument here is just something that should be in the current directory
 # (for sanity checking)
 AC_CONFIG_SRCDIR(README)


### PR DESCRIPTION
The version number has not been updated for release 2.0.3 in autoconf. As a result, the pkconfig file reports wrong version number.